### PR TITLE
fix(LSLClient): corrected "type" case

### DIFF
--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -105,7 +105,7 @@ class LSLClient(_BaseClient):
         for k in range(1,  lsl_info.channel_count() + 1):
             ch_names.append(ch_info.child_value("label") or
                             '{} {:03d}'.format(ch_type.upper(), k))
-            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_types.append(ch_info.child_value("type").lower() or ch_type)
             ch_info = ch_info.next_sibling()
         if ch_type == "eeg":
             try:

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -19,8 +19,11 @@ class LSLClient(_BaseClient):
     ----------
     info : instance of mne.Info | None
         The measurement info read in from a file. If None, it is generated from
-        the LSL stream. This method may result in less info than expected. If
-        the channel type is EEG, the `standard_1005` montage is used for
+        the LSL stream. This method may result in less info than expected.
+        Also, the channel type of the LSL stream must be one the MNE supported
+        channel types: ‘ecg’, ‘bio’, ‘stim’, ‘eog’, ‘misc’, ‘seeg’,
+        ‘ecog’, ‘mag’, ‘eeg’, ‘ref_meg’, ‘grad’, ‘emg’, ‘hbr’ or ‘hbo’.
+        If the channel type is EEG, the `standard_1005` montage is used for
         electrode location.
     host : str
         The LSL identifier of the server. This is the source_id designated


### PR DESCRIPTION
Resolves error when "type = EEG" (_uppercase_) part of channel info.     Otherwise, one gets error: 
`KeyError: "kind must be one of ['eeg', 'mag', 'grad', 'ref_meg', 'misc', 'stim', 'eog', 'ecg', 'emg', 'seeg', 'bio', 'ecog', 'hbo', 'hbr'], not EEG"`