### PR TITLE
add fast bandpass filter

### DIFF
--- a/mne_realtime/rt_filter.py
+++ b/mne_realtime/rt_filter.py
@@ -2,13 +2,14 @@
 """
 Created on Fri Mar 19 13:30:38 2021
 
-@author: Timon Merk
+# Author: Timon Merk <timon.merk95@gmail.com>
 """
 
 import numpy as np 
 import mne 
 
-def calc_band_filters(f_ranges, sample_rate, filter_len="1000ms", l_trans_bandwidth=4, h_trans_bandwidth=4):
+
+def calc_band_filters(f_ranges, sfreq, filter_length="1000ms", l_trans_bandwidth=4, h_trans_bandwidth=4):
     """"Calculate bandpass filters with adjustable length for given frequency ranges.
     This function returns for the given frequency band ranges the filter coefficients with length "filter_len".
     Thus the filters can be sequentially used for band power estimation.
@@ -16,50 +17,53 @@ def calc_band_filters(f_ranges, sample_rate, filter_len="1000ms", l_trans_bandwi
     ----------
     f_ranges : list of lists
         frequency ranges.
-    sample_rate : float
+    sfreq : float
         sampling frequency.
-    filter_len : str, optional
+    filter_length : str, optional
         length of the filter. Human readable (e.g."1000ms" or "1s"). Default is "1000ms"
-    l_trans_bandwidth : int/float, optional
+    l_trans_bandwidth : float, optional
         Length of the lower transition band. The default is 4.
-    h_trans_bandwidth : int/float, optional
+    h_trans_bandwidth : float, optional
         Length of the higher transition band. The default is 4.
     Returns
     -------
-    filter_bank : array
-        filter coefficients stored in array of shape (n_franges, filter_len (in samples))
+    filter_bank : ndarray, shape(n_franges, filter length samples)
+        filter coefficients
     """
-    filter_list = []
-    for a, f_range in enumerate(f_ranges):
-        h = mne.filter.create_filter(None, sample_rate, l_freq=f_range[0], h_freq=f_range[1], fir_design='firwin',
+    filter_list = list()
+    for f_range in f_ranges:
+        h = mne.filter.create_filter(None, sfreq, l_freq=f_range[0], h_freq=f_range[1], fir_design='firwin',
                                         l_trans_bandwidth=l_trans_bandwidth, h_trans_bandwidth=h_trans_bandwidth,
-                                        filter_length=filter_len)
+                                        filter_length=filter_length)
         filter_list.append(h)
     filter_bank = np.vstack(filter_list)
     return filter_bank
 
-def apply_filter(dat_, filter_bank, fs):
+
+def apply_filter(data, filter_bank, sfreq):
         """Apply previously calculated (bandpass) filters to data.
         Parameters
         ----------
-        dat_ : array (n_samples, ) or (n_channels, n_samples)
+        data : array (n_samples, ) or (n_channels, n_samples)
             segment of data.
         filter_bank : array
             output of calc_band_filters.
+        sfreq : float
+            sampling frequency.
         Returns
         -------
         filtered : array
             (n_chan, n_fbands, filter_len) array conatining the filtered signal
             at each freq band, where n_fbands is the number of filter bands used to decompose the signal
         """    
-        if dat_.ndim == 1:
-            filtered = np.zeros((1, filter_bank.shape[0], fs))
+        if data.ndim == 1:
+            filtered = np.zeros((1, filter_bank.shape[0], sfreq))
             for filt in range(filter_bank.shape[0]):
-                filtered[0, filt, :] = np.convolve(filter_bank[filt,:], dat_)[int(fs-fs/2):int(fs+fs/2)]
-        elif dat_.ndim == 2:
-            filtered = np.zeros((dat_.shape[0], filter_bank.shape[0], fs))
-            for chan in range(dat_.shape[0]):
+                filtered[0, filt, :] = np.convolve(filter_bank[filt,:], data)[int(sfreq-sfreq/2):int(sfreq+sfreq/2)]
+        elif data.ndim == 2:
+            filtered = np.zeros((data.shape[0], filter_bank.shape[0], sfreq))
+            for chan in range(data.shape[0]):
                 for filt in range(filter_bank.shape[0]):
                     filtered[chan, filt, :] = np.convolve(filter_bank[filt, :], \
-                                                        dat_[chan,:])[int(fs-fs/2):int(fs+fs/2)] # mode="full"
+                                                        data[chan,:])[int(sfreq-sfreq/2):int(sfreq+sfreq/2)] # mode="full"
         return filtered

--- a/mne_realtime/rt_filter.py
+++ b/mne_realtime/rt_filter.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Mar 19 13:30:38 2021
+
+@author: Timon Merk
+"""
+
+import numpy as np 
+import mne 
+
+def calc_band_filters(f_ranges, sample_rate, filter_len="1000ms", l_trans_bandwidth=4, h_trans_bandwidth=4):
+    """"Calculate bandpass filters with adjustable length for given frequency ranges.
+    This function returns for the given frequency band ranges the filter coefficients with length "filter_len".
+    Thus the filters can be sequentially used for band power estimation.
+    Parameters
+    ----------
+    f_ranges : list of lists
+        frequency ranges.
+    sample_rate : float
+        sampling frequency.
+    filter_len : str, optional
+        length of the filter. Human readable (e.g."1000ms" or "1s"). Default is "1000ms"
+    l_trans_bandwidth : int/float, optional
+        Length of the lower transition band. The default is 4.
+    h_trans_bandwidth : int/float, optional
+        Length of the higher transition band. The default is 4.
+    Returns
+    -------
+    filter_bank : array
+        filter coefficients stored in array of shape (n_franges, filter_len (in samples))
+    """
+    filter_list = []
+    for a, f_range in enumerate(f_ranges):
+        h = mne.filter.create_filter(None, sample_rate, l_freq=f_range[0], h_freq=f_range[1], fir_design='firwin',
+                                        l_trans_bandwidth=l_trans_bandwidth, h_trans_bandwidth=h_trans_bandwidth,
+                                        filter_length=filter_len)
+        filter_list.append(h)
+    filter_bank = np.vstack(filter_list)
+    return filter_bank
+
+def apply_filter(dat_, filter_bank, fs):
+        """Apply previously calculated (bandpass) filters to data.
+        Parameters
+        ----------
+        dat_ : array (n_samples, ) or (n_channels, n_samples)
+            segment of data.
+        filter_bank : array
+            output of calc_band_filters.
+        Returns
+        -------
+        filtered : array
+            (n_chan, n_fbands, filter_len) array conatining the filtered signal
+            at each freq band, where n_fbands is the number of filter bands used to decompose the signal
+        """    
+        if dat_.ndim == 1:
+            filtered = np.zeros((1, filter_bank.shape[0], fs))
+            for filt in range(filter_bank.shape[0]):
+                filtered[0, filt, :] = np.convolve(filter_bank[filt,:], dat_)[int(fs-fs/2):int(fs+fs/2)]
+        elif dat_.ndim == 2:
+            filtered = np.zeros((dat_.shape[0], filter_bank.shape[0], fs))
+            for chan in range(dat_.shape[0]):
+                for filt in range(filter_bank.shape[0]):
+                    filtered[chan, filt, :] = np.convolve(filter_bank[filt, :], \
+                                                        dat_[chan,:])[int(fs-fs/2):int(fs+fs/2)] # mode="full"
+        return filtered


### PR DESCRIPTION
Based on #26 I want to push a faster bandpass filter estimation than the [mne.filter.filter_data](https://mne.tools/stable/generated/mne.filter.filter_data.html).

I also wrote a notebook where I compare the two on my private repo: 
https://github.com/neuromodulation/py_neuromodulation/blob/main/examples/speedtests/speedtest_filter_vs_MNE.ipynb

There you can see that the initialized rt_filter.py estimation took ~6 ms while the mne.filter.filter_data took ~31 ms. Both is based on a sampling frequency of 500 Hz and 6 channels. 

@teonbrooks  Do you think it might be a good idea to upload such an example as well maybe in a folder called "real time tests"? 
