### PR TITLE
channel type needs to be lower case for MNE info

### DIFF
--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -121,7 +121,7 @@ class LSLClient(_BaseClient):
         for k in range(1,  lsl_info.channel_count() + 1):
             ch_names.append(ch_info.child_value("label") or
                             '{} {:03d}'.format(ch_type.upper(), k))
-            ch_types.append(ch_info.child_value("type") or ch_type)
+            ch_types.append(ch_info.child_value("type").lower() or ch_type)
             ch_info = ch_info.next_sibling()
         if ch_type == "eeg":
             info = create_info(ch_names, sfreq, ch_types)


### PR DESCRIPTION
Otherwise a Key Error will be thrown: 

> Traceback (most recent call last):
> 
>   File "c:\users\icn_admin\documents\code_sprint\mne-realtime\examples\openbci_test.py", line 21, in <module>
>     with LSLClient(host="openbci_eeg_id127", wait_max=wait_max) as client:
> 
>   File "c:\users\icn_admin\documents\code_sprint\mne-realtime\mne_realtime\base_client.py", line 79, in __enter__
>     self.info = self._create_info()
> 
>   File "c:\users\icn_admin\documents\code_sprint\mne-realtime\mne_realtime\lsl_client.py", line 127, in _create_info
>     info = create_info(ch_names, sfreq, ch_types)
> 
>   File "<decorator-gen-30>", line 24, in create_info
> 
>   File "C:\Users\ICN_admin\Anaconda3\envs\MNERealTime\lib\site-packages\mne\io\meas_info.py", line 2053, in create_info
>     raise KeyError(f'kind must be one of {list(ch_types_dict)}, '
> 
> KeyError: "kind must be one of ['grad', 'mag', 'ref_meg', 'eeg', 'seeg', 'dbs', 'ecog', 'eog', 'emg', 'ecg', 'resp', 'bio', 'misc', 'stim', 'exci', 'syst', 'ias', 'gof', 'dipole', 'chpi', 'fnirs_cw_amplitude', 'fnirs_fd_ac_amplitude', 'fnirs_fd_phase', 'fnirs_od', 'hbo', 'hbr', 'csd'], not EEG"