### PR TITLE
Propagate any errors occurring within the `_BaseClient` context

### DIFF
--- a/mne_realtime/base_client.py
+++ b/mne_realtime/base_client.py
@@ -87,8 +87,6 @@ class _BaseClient(object):
     def __exit__(self, type, value, traceback):
         self._disconnect()
 
-        return self
-
     @fill_doc
     def get_data_as_epoch(self, n_samples=1024, picks=None):
         """Return last n_samples from current time.

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -79,7 +79,7 @@ class LSLClient(_BaseClient):
         return EpochsArray(data[picks][np.newaxis], info, events)
 
     def iter_raw_buffers(self):
-        """Return an iterator over raw buffers."""
+        """Return an infinite iterator over raw buffers."""
         while True:
             samples, _ = self.client.pull_chunk(max_samples=self.buffer_size)
             if not len(samples):

--- a/mne_realtime/mock_lsl_stream.py
+++ b/mne_realtime/mock_lsl_stream.py
@@ -94,9 +94,11 @@ class MockLSLStream(object):
             mysample = self._raw[:, counter][0].ravel()
             # now send it and wait for a bit
             if self._status and counter % every == 0:
-                print(f'Sending sample {counter} on {self._host}, '
+                print(f'Sending sample {counter}/{self._raw.last_samp} '
+                      f'of length {len(mysample)} on {self._host}, '
                       f'have_consumers={outlet.have_consumers()}')
-            outlet.push_sample(mysample)
+            if len(mysample) > 0:
+                outlet.push_sample(mysample)
             counter = 0 if counter == self._raw.last_samp else counter + 1
             next_t += delta
             sleep = next_t - time.time()

--- a/mne_realtime/tests/test_base_client.py
+++ b/mne_realtime/tests/test_base_client.py
@@ -1,0 +1,20 @@
+# Author: Charles Guan <charles@ae.studio>
+#
+# License: BSD (3-clause)
+
+import pytest
+
+from mne_realtime.base_client import _BaseClient
+
+
+def test_base_client():
+    """Initialize _BaseClient as context manager."""
+    with _BaseClient() as client:
+        pass
+
+
+def test_base_client_propagate_exception():
+    """_BaseClient propagates exceptions to user."""
+    with pytest.raises(Exception):
+        with _BaseClient() as client:
+            raise Exception

--- a/mne_realtime/tests/test_lsl_client.py
+++ b/mne_realtime/tests/test_lsl_client.py
@@ -32,9 +32,6 @@ def test_lsl_client():
             client_info = client.get_measurement_info()
             n_samples = math.ceil(sfreq * n_secs * 2)
             epoch = client.get_data_as_epoch(n_samples=n_samples)
-            time.sleep(1.)
-            raw = list(client.iter_raw_buffers())
-            assert len(raw) > 0
 
     assert client_info['nchan'] == raw_info['nchan']
     assert ([ch["ch_name"] for ch in client_info["chs"]] ==

--- a/mne_realtime/tests/test_lsl_client.py
+++ b/mne_realtime/tests/test_lsl_client.py
@@ -1,6 +1,7 @@
 # Author: Teon Brooks <teon.brooks@gmail.com>
 #
 # License: BSD (3-clause)
+import math
 from os import getenv, path as op
 import time
 import pytest
@@ -29,7 +30,8 @@ def test_lsl_client():
     with MockLSLStream(host, raw, ch_type='eeg', status=True):
         with LSLClient(info=raw_info, host=host, wait_max=5) as client:
             client_info = client.get_measurement_info()
-            epoch = client.get_data_as_epoch(n_samples=sfreq * n_secs * 2)
+            n_samples = math.ceil(sfreq * n_secs * 2)
+            epoch = client.get_data_as_epoch(n_samples=n_samples)
             time.sleep(1.)
             raw = list(client.iter_raw_buffers())
             assert len(raw) > 0

--- a/mne_realtime/tests/test_lsl_client.py
+++ b/mne_realtime/tests/test_lsl_client.py
@@ -24,7 +24,7 @@ def test_lsl_client():
     """Test the LSLClient for connection and data retrieval."""
     raw = read_raw_fif(raw_fname)
     n_secs = 1
-    raw.crop(n_secs)
+    raw.crop(tmin=0, tmax=n_secs)
     raw_info = raw.info
     sfreq = raw_info['sfreq']
     with MockLSLStream(host, raw, ch_type='eeg', status=True):


### PR DESCRIPTION
Current behavior: any Exceptions occurring within a `_BaseClient` context exit the context but do not propagate any errors.

From https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers about `__exit__`:
```
If an exception is supplied, and the method wishes to suppress the exception (i.e., prevent it from being propagated), it should return a true value. Otherwise, the exception will be processed normally upon exit from this method.
```
(Note that `return self` acts as a true value here)

New behavior: Exceptions are propagated through the context.

This helps user track down where an error came from.