### PR TITLE
Pre-allocate buffer for `pylsl`'s `.pull_chunk` for faster reads

### DIFF
--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -72,7 +72,7 @@ class LSLClient(_BaseClient):
         # create an event at the start of the data collection
         events = np.expand_dims(np.array([0, 1, 1]), axis=0)
         _, timestamps = self.client.pull_chunk(
-            max_samples=self.buffer.shape[0],
+            max_samples=min(n_samples, self.buffer.shape[0]),
             timeout=wait_time,
             dest_obj=self.buffer,
         )

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -76,7 +76,7 @@ class LSLClient(_BaseClient):
             timeout=wait_time,
             dest_obj=self.buffer,
         )
-        data = self.buffer[:len(timestamps), :]
+        data = self.buffer[:len(timestamps)].transpose()  # n_channels x n_samples
 
         picks = _picks_to_idx(self.info, picks, 'all', exclude=())
         info = pick_info(self.info, picks)
@@ -89,7 +89,7 @@ class LSLClient(_BaseClient):
                 max_samples=self.buffer.shape[0],
                 dest_obj=self.buffer,
             )
-            data = self.buffer[:len(timestamps), :]
+            data = self.buffer[:len(timestamps)].transpose()  # n_channels x n_samples
             yield data.copy()
 
     def _connect(self):

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -76,7 +76,6 @@ class LSLClient(_BaseClient):
             timeout=wait_time,
             dest_obj=self.buffer,
         )
-        num_timestamps = len(timestamps) if timestamps else 0
         data = self.buffer[:len(timestamps), :]
 
         picks = _picks_to_idx(self.info, picks, 'all', exclude=())
@@ -90,7 +89,6 @@ class LSLClient(_BaseClient):
                 max_samples=self.buffer.shape[0],
                 dest_obj=self.buffer,
             )
-            num_timestamps = len(timestamps) if timestamps else 0
             data = self.buffer[:len(timestamps), :]
             yield data.copy()
 

--- a/mne_realtime/tests/test_lsl_client.py
+++ b/mne_realtime/tests/test_lsl_client.py
@@ -46,6 +46,7 @@ def test_lsl_client():
 
     assert raw_info['nchan'], sfreq == epoch.get_data().shape[1:]
 
+@requires_pylsl
 def test_connect(mocker):
     """Mock connect to LSL stream."""
     # Constants

--- a/mne_realtime/tests/test_lsl_client.py
+++ b/mne_realtime/tests/test_lsl_client.py
@@ -33,6 +33,11 @@ def test_lsl_client():
             n_samples = math.ceil(sfreq * n_secs * 2)
             epoch = client.get_data_as_epoch(n_samples=n_samples)
 
+            epoch_data = epoch.get_data()
+            n_epochs, n_channels, n_times = epoch_data.shape
+            assert n_epochs == 1
+            assert n_channels == client_info['nchan']
+
     assert client_info['nchan'] == raw_info['nchan']
     assert ([ch["ch_name"] for ch in client_info["chs"]] ==
             [ch_name for ch_name in raw_info['ch_names']])

--- a/mne_realtime/tests/test_lsl_client.py
+++ b/mne_realtime/tests/test_lsl_client.py
@@ -10,9 +10,9 @@ from mne.utils import requires_pylsl
 from mne.io import read_raw_fif
 from mne.datasets import testing
 import numpy as np
-import pylsl
 
 from mne_realtime import LSLClient, MockLSLStream
+from mne_realtime.lsl_client import _check_pylsl_installed
 
 base_dir = op.join(op.dirname(__file__), 'data')
 
@@ -49,6 +49,9 @@ def test_lsl_client():
 @requires_pylsl
 def test_connect(mocker):
     """Mock connect to LSL stream."""
+    # Import pylsl here so that the test can be skipped if pylsl is not installed
+    pylsl = _check_pylsl_installed(strict=True)
+
     # Constants
     buffer_size = 17
     n_channels = 6

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ sip
 scikit-learn
 pytest
 pytest-cov
+pytest-mock
 numpydoc
 pydocstyle
 flake8


### PR DESCRIPTION
Useful for high sampling rates (and just better latency), as recommended by: https://labstreaminglayer.readthedocs.io/info/faqs.html#high-sampling-rates