### PR TITLE
Fix example code in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,8 @@ Quickstart
                          tmax=30, wait_max=5, info=info) as rt_client:
         rt_epochs = RtEpochs(rt_client, event_id, tmin, tmax, ...)
         rt_epochs.start()
-        for ev in rt_epochs.iter_evoked():
-            epoch_data = ev.data
+        for epoch in rt_epochs:
+            epoch_data = epoch.get_data()
 
         # or alternatively, get last n_samples
         rt_epoch = rt_client.get_data_as_epoch(n_samples=500)


### PR DESCRIPTION
Use updated interfaces for `RtEpochs` generator and `mne.Epochs.get_data()`

* `.iter_evoked()` seems to have been removed from `RtEpochs`. The code seems to suggest the use of direct iteration over the object (https://github.com/mne-tools/mne-realtime/blob/main/mne_realtime/epochs.py#L311-L351)
* `mne.Epochs` does not have appear to have a `.data` field (in MNE 1.3), but instead its public API lists `.get_data()` https://mne.tools/stable/generated/mne.Epochs.html#mne.Epochs.get_data