### PR TITLE
Make `.get_data_as_epoch` timeout a configurable parameter

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -347,6 +347,7 @@ numpydoc_xref_aliases = {
     'DigMontage': 'mne.channels.DigMontage',
     'ConductorModel': 'mne.bem.ConductorModel',
     'EpochsSpectrum': 'mne.time_frequency.EpochsSpectrum',
+    'EpochsArray': 'mne.EpochsArray',
     # mne_realtime
     'RtEpochs': 'mne_realtime.RtEpochs',
 }

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -48,14 +48,17 @@ class LSLClient(_BaseClient):
     """
 
     @fill_doc
-    def get_data_as_epoch(self, n_samples=1024, picks=None):
-        """Return last n_samples from current time.
+    def get_data_as_epoch(self, n_samples=1024, picks=None, timeout=None):
+        """Return n_samples from LSL in FIFO order.
 
         Parameters
         ----------
         n_samples : int
             Number of samples to fetch.
         %(picks_all)s
+        timeout : Optional[float]
+            Maximum amount of time to wait for data from LSL
+            if None: waits for 5x n_samples / sfreq
 
         Returns
         -------
@@ -66,14 +69,15 @@ class LSLClient(_BaseClient):
         --------
         mne.Epochs.iter_evoked
         """
-        # set up timeout in case LSL process hang. wait arb 5x expected time
-        wait_time = n_samples * 5. / self.info['sfreq']
+        if timeout is None:
+            # set up timeout in case LSL process hang. wait arb 5x expected time
+            timeout = n_samples * 5. / self.info['sfreq']
 
         # create an event at the start of the data collection
         events = np.expand_dims(np.array([0, 1, 1]), axis=0)
         _, timestamps = self.client.pull_chunk(
             max_samples=min(n_samples, self.buffer.shape[0]),
-            timeout=wait_time,
+            timeout=timeout,
             dest_obj=self.buffer,
         )
         data = self.buffer[:len(timestamps)].transpose()  # n_channels x n_samples

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -56,7 +56,7 @@ class LSLClient(_BaseClient):
         n_samples : int
             Number of samples to fetch.
         %(picks_all)s
-        timeout : Optional[float]
+        timeout : float | None
             Maximum amount of time to wait for data from LSL
             if None: waits for 5x n_samples / sfreq
 

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -62,7 +62,7 @@ class LSLClient(_BaseClient):
 
         Returns
         -------
-        epoch : Optional[EpochsArray]
+        epoch : instance of EpochsArray | None
             The samples fetched as an Epochs object.
             None if no data was returned from pylsl.
 

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -62,8 +62,9 @@ class LSLClient(_BaseClient):
 
         Returns
         -------
-        epoch : instance of Epochs
+        epoch : Optional[EpochsArray]
             The samples fetched as an Epochs object.
+            None if no data was returned from pylsl.
 
         See Also
         --------
@@ -80,6 +81,9 @@ class LSLClient(_BaseClient):
             timeout=timeout,
             dest_obj=self.buffer,
         )
+        if not timestamps:
+            return None
+
         data = self.buffer[:len(timestamps)].transpose()  # n_channels x n_samples
 
         picks = _picks_to_idx(self.info, picks, 'all', exclude=())

--- a/mne_realtime/tests/test_lsl_client.py
+++ b/mne_realtime/tests/test_lsl_client.py
@@ -46,6 +46,18 @@ def test_lsl_client():
 
     assert raw_info['nchan'], sfreq == epoch.get_data().shape[1:]
 
+
+@requires_pylsl
+@testing.requires_testing_data
+def test_lsl_client_nodata():
+    """Test that LSLClient gracefully handles no-data from LSL."""
+    raw = read_raw_fif(raw_fname)
+    raw_info = raw.info
+    with MockLSLStream(host, raw, ch_type='eeg', status=True):
+        with LSLClient(info=raw_info, host=host, wait_max=5) as client:
+            epoch = client.get_data_as_epoch(n_samples=0, timeout=0)
+            assert epoch is None
+
 @requires_pylsl
 def test_connect(mocker):
     """Mock connect to LSL stream."""


### PR DESCRIPTION
As someone creating a real-time application, I sometimes want to limit the amount of time the application is waiting on data. This change makes `wait_time` (now called `timeout`) a configurable parameter.

In the situation that data is not ready before the timeout, `.get_data_as_epoch` now returns `None` because `EpochsArray(data,...)` errors out when `data` is an empty array.
Note: it was possible for `data` to be empty even before the change, although a shorter `timeout` now makes this more likely.