### PR TITLE
Optionally check for LSL stream name

### DIFF
--- a/mne_realtime/base_client.py
+++ b/mne_realtime/base_client.py
@@ -51,7 +51,8 @@ class _BaseClient(object):
 
     def __init__(self, info=None, host='localhost', port=None,
                  wait_max=10., tmin=None, tmax=np.inf,
-                 buffer_size=1000, host_name=None, verbose=None):  # noqa: D102
+                 buffer_size=1000, *, host_name=None,
+                 verbose=None):  # noqa: D102
         self.info = info
         self.host = host
         self.port = port

--- a/mne_realtime/base_client.py
+++ b/mne_realtime/base_client.py
@@ -43,12 +43,15 @@ class _BaseClient(object):
         Time instant to stop receiving buffers.
     buffer_size : int
         Size of each buffer in terms of number of samples.
+    host_name : str | None
+        The name of the server, e.g. the LSL stream name.
+        If None, the name is ignored.
     %(verbose)s
     """
 
     def __init__(self, info=None, host='localhost', port=None,
                  wait_max=10., tmin=None, tmax=np.inf,
-                 buffer_size=1000, verbose=None):  # noqa: D102
+                 buffer_size=1000, host_name=None, verbose=None):  # noqa: D102
         self.info = info
         self.host = host
         self.port = port
@@ -56,6 +59,7 @@ class _BaseClient(object):
         self.tmin = tmin
         self.tmax = tmax
         self.buffer_size = buffer_size
+        self.host_name = host_name
         self.verbose = verbose
         self._recv_thread = None
         self._recv_callbacks = list()

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -112,13 +112,17 @@ class LSLClient(_BaseClient):
         # resolve_byprop is a bit fragile
         streams = pylsl.resolve_streams(wait_time=min(1.0, self.wait_max))
         ids = list()
+        matching_streams = list()
         for stream_info in streams:
             ids.append(stream_info.source_id())
             if stream_info.source_id() == self.host:
                 if (self.host_name is None) or (stream_info.name() == self.host_name):
-                    break
-        else:
+                    matching_streams.append(stream_info)
+        if not matching_streams:
             raise RuntimeError(f'{(self.host, self.host_name)} not found in streams: {ids}')
+        if len(matching_streams) > 1:
+            raise RuntimeError(f'{(self.host, self.host_name)} not unique in streams: {ids}')
+        stream_info = matching_streams[0]
         print(f'Found stream {repr(stream_info.name())} via '
               f'{stream_info.source_id()}...')
         self.client = pylsl.StreamInlet(info=stream_info,

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -123,7 +123,7 @@ class LSLClient(_BaseClient):
         pylsl = _check_pylsl_installed(strict=True)
         print(f'Looking for LSL stream {self.host}...')
         # resolve_byprop is a bit fragile
-        streams = pylsl.resolve_streams(wait_time=min(0.1, self.wait_max))
+        streams = pylsl.resolve_streams(wait_time=min(1.0, self.wait_max))
         ids = list()
         for stream_info in streams:
             ids.append(stream_info.source_id())

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -28,9 +28,10 @@ class LSLClient(_BaseClient):
         electrode location.
     host : str
         The LSL identifier of the server. This is the source_id designated
-        when the LSL stream was created. Make sure the source_id is unique on
-        the LSL subnet. For more information on LSL, please check the
-        docstrings on `StreamInfo` and `StreamInlet` in the pylsl.
+        when the LSL stream was created. If the source_id is not unique on
+        the LSL subnet, specify the `host_name` parameter, too. For more information
+        on LSL, please check the docstrings on `StreamInfo` and `StreamInlet`
+        in the pylsl library.
     port : int | None
         Port to use for the connection.
     wait_max : float
@@ -42,12 +43,12 @@ class LSLClient(_BaseClient):
         Time instant to stop receiving buffers.
     buffer_size : int
         Size of each buffer in terms of number of samples.
-    verbose : bool, str, int, or None
-        If not None, override default verbose level (see :func:`mne.verbose`
-        for more).
     host_name : str | None
         The name of the LSL stream. If None, this is ignored when looking for
          matching streams.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see :func:`mne.verbose`
+        for more).
     """
 
     def __init__(self, info=None, host='localhost', port=None,

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -51,20 +51,6 @@ class LSLClient(_BaseClient):
         for more).
     """
 
-    def __init__(self, info=None, host='localhost', port=None,
-                 wait_max=10., tmin=None, tmax=np.inf,
-                 buffer_size=1000, verbose=None, host_name=None):  # noqa: D102
-        super(LSLClient, self).__init__(
-            info=info,
-            host=host,
-            port=port,
-            wait_max=wait_max,
-            tmin=tmin,
-            tmax=tmax,
-            buffer_size=buffer_size,
-            verbose=verbose)
-        self.host_name = host_name
-
     @fill_doc
     def get_data_as_epoch(self, n_samples=1024, picks=None, timeout=None):
         """Return n_samples from LSL in FIFO order.

--- a/mne_realtime/tests/test_lsl_client.py
+++ b/mne_realtime/tests/test_lsl_client.py
@@ -106,3 +106,24 @@ def test_connect_stream_not_found(mocker):
     lsl_client = LSLClient(host=host, host_name=stream_name)
     with pytest.raises(RuntimeError):
         lsl_client._connect()
+
+@requires_pylsl
+def test_connect_nonunique_streams(mocker):
+    """Mock attempt to connect to LSL stream with non-unique name."""
+    # Import pylsl here so that the test can be skipped if pylsl is not installed
+    pylsl = _check_pylsl_installed(strict=True)
+
+    # Replace pylsl streams with a mock
+    mock_resolve_streams = mocker.patch(
+        'pylsl.resolve_streams',
+        return_value=[
+            pylsl.StreamInfo(source_id=host, name="stream 1"),
+            pylsl.StreamInfo(source_id=host, name="stream 2"),
+        ],
+    )
+
+    # Connection errors out, because there are multiple
+    # streams with the same source ID
+    lsl_client = LSLClient(host=host)
+    with pytest.raises(RuntimeError):
+        lsl_client._connect()

--- a/mne_realtime/tests/test_lsl_client.py
+++ b/mne_realtime/tests/test_lsl_client.py
@@ -87,3 +87,22 @@ def test_connect(mocker):
     assert isinstance(lsl_client.client, pylsl.StreamInlet)
     assert lsl_client.buffer.shape == (buffer_size, n_channels)
     assert lsl_client.buffer.dtype == numpy_channel_format
+
+@requires_pylsl
+def test_connect_stream_not_found(mocker):
+    """Mock attempt to connect to non-existent LSL stream."""
+    # Import pylsl here so that the test can be skipped if pylsl is not installed
+    pylsl = _check_pylsl_installed(strict=True)
+
+    # Replace pylsl streams with a mock
+    mock_resolve_streams = mocker.patch(
+        'pylsl.resolve_streams',
+        return_value=[pylsl.StreamInfo(
+            source_id=host,
+        )],
+    )
+
+    stream_name = "non-existent stream"
+    lsl_client = LSLClient(host=host, host_name=stream_name)
+    with pytest.raises(RuntimeError):
+        lsl_client._connect()


### PR DESCRIPTION
In addition to checking for a matching LSL stream source ID.

This is useful in the case that a device uses its serial number as its source ID and generates more than one LSL stream: (e.g., a marker stream and a data stream coming from the same device).

This issue comes up with the Neurosity Crown, for example:
```python
>>> import pylsl
>>> streams = pylsl.resolve_streams('eeg')
>>> [(stream.name(), stream.source_id()) for stream in streams]
[('Crown-459 Markers', '4599f267492346b97fda95666a33d868'), ('Crown-459', '4599f267492346b97fda95666a33d868')]
```

In this case, it is necessary to specify both the host name and source ID to select the correct stream.

Also extends the pylsl Stream connection timeout to the default of 1 second, as recommended by https://github.com/labstreaminglayer/pylsl/blob/master/pylsl/pylsl.py#L535-L538:

> Warning: If this is too short (<0.5s) only a subset
>                  (or none) of the outlets that are present on the network may
>                  be returned. (default 1.0)
