### PR TITLE
MAINT: Use explicitly public APIs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,6 @@
-# Configuration for coverage.py
-
 [run]
 branch = True
 source = mne_realtime
-include = */mne_realtime/*
 omit =
     */setup.py
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -298,6 +298,8 @@ def reset_warnings(gallery_conf, fname):
         'ignore', message=".*ufunc size changed.*", category=RuntimeWarning)
     warnings.filterwarnings(  # realtime
         'ignore', message=".*unclosed file.*", category=ResourceWarning)
+    warnings.filterwarnings(
+        'ignore', message='The str interface for _CascadingStyleSheet.*')
     warnings.filterwarnings('ignore', message='Exception ignored in.*')
     # allow this ImportWarning, but don't show it
     warnings.filterwarnings(

--- a/mne_realtime/client.py
+++ b/mne_realtime/client.py
@@ -13,9 +13,14 @@ import numpy as np
 
 from mne.utils import logger, verbose, fill_doc
 from mne.io.constants import FIFF
-from mne.io.meas_info import read_meas_info
-from mne.io.tag import Tag, read_tag
-from mne.io.tree import make_dir_tree
+try:
+    from mne._fiff.meas_info import read_meas_info
+    from mne._fiff.tag import Tag, read_tag
+    from mne._fiff.tree import make_dir_tree
+except ImportError:  # MNE < 1.6
+    from mne.io.meas_info import read_meas_info
+    from mne.io.tag import Tag, read_tag
+    from mne.io.tree import make_dir_tree
 
 # Constants for fiff realtime fiff messages
 MNE_RT_GET_CLIENT_ID = 1

--- a/mne_realtime/fieldtrip_client.py
+++ b/mne_realtime/fieldtrip_client.py
@@ -9,8 +9,8 @@ import time
 
 import numpy as np
 
-from mne.io import _empty_info
-from mne.io.pick import _picks_to_idx, pick_info
+from mne import create_info, pick_info
+from mne.io.pick import _picks_to_idx
 from mne.io.constants import FIFF
 from mne.epochs import EpochsArray
 from mne.utils import logger, warn, fill_doc
@@ -141,7 +141,7 @@ class FieldTripClient(object):
             warn('Info dictionary not provided. Trying to guess it from '
                  'FieldTrip Header object')
 
-            info = _empty_info(self.ft_header.fSample)  # create info
+            info = create_info(1, self.ft_header.fSample, 'mag')  # create info
             info._unlocked = True
 
             # modify info attributes according to the FieldTrip Header object

--- a/mne_realtime/lsl_client.py
+++ b/mne_realtime/lsl_client.py
@@ -7,9 +7,9 @@ import ctypes
 import numpy as np
 
 from .base_client import _BaseClient
+from mne import create_info, pick_info
 from mne.epochs import EpochsArray
-from mne.io.meas_info import create_info
-from mne.io.pick import _picks_to_idx, pick_info
+from mne.io.pick import _picks_to_idx
 from mne.utils import fill_doc
 
 


### PR DESCRIPTION
In https://github.com/mne-tools/mne-python/pull/11903 we're trying to make some mne/io stuff private. This changes mne-realtime to use the explicitly public API, except for the tag and `meas_info` reading because that unfortunately has to stay low-level