### PR TITLE
MAINT: Permissive doc building

### DIFF
--- a/doc/mne_realtime_doc_helper.py
+++ b/doc/mne_realtime_doc_helper.py
@@ -20,8 +20,8 @@ def reset_warnings(gallery_conf, fname):
 
     # remove tweaks from other module imports or example runs
     warnings.resetwarnings()
-    # restrict
-    warnings.filterwarnings('error')
+    # allow warnings now that mne-realtime is deprecated
+    warnings.filterwarnings('always')
     # allow these, but show them
     warnings.filterwarnings('default', module='sphinx')  # internal warnings
     # allow these warnings, but don't show them


### PR DESCRIPTION
No reason for us to [be strict](https://app.circleci.com/pipelines/github/mne-tools/mne-realtime/474/workflows/92fdcdc2-b3a7-41ab-a674-b96ab31df423/jobs/627) with the doc build warnings (during import etc.) for a project that's deprecated, this leads mostly to unnecessary maintenance churn. If something breaks down the line we'll fix it then, but hopefully won't have to